### PR TITLE
[CI] Move update_rapids workflow to xgboost-devops

### DIFF
--- a/.github/workflows/update_rapids.yml
+++ b/.github/workflows/update_rapids.yml
@@ -1,0 +1,44 @@
+name: update-rapids
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 20 * * 1"  # Run once weekly
+
+permissions:
+  pull-requests: write
+  contents: write
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # To use GitHub CLI
+
+jobs:
+  update-rapids:
+    name: Check latest RAPIDS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+      - name: Check latest RAPIDS and update conftest.sh
+        run: |
+          bash containers/update_rapids.sh
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        if: github.ref == 'refs/heads/master'
+        with:
+          add-paths: |
+            ops/docker
+          branch: create-pull-request/update-rapids
+          base: master
+          title: "[CI] Update RAPIDS to latest stable"
+          commit-message: "[CI] Update RAPIDS to latest stable"
+      

--- a/.github/workflows/update_rapids.yml
+++ b/.github/workflows/update_rapids.yml
@@ -41,4 +41,3 @@ jobs:
           base: master
           title: "[CI] Update RAPIDS to latest stable"
           commit-message: "[CI] Update RAPIDS to latest stable"
-      

--- a/containers/update_rapids.sh
+++ b/containers/update_rapids.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+LATEST_RAPIDS_VERSION=$(gh api repos/rapidsai/cuml/releases/latest --jq '.name' | sed -e 's/^v\([[:digit:]]\+\.[[:digit:]]\+\).*/\1/')
+echo "LATEST_RAPIDS_VERSION = $LATEST_RAPIDS_VERSION"
+DEV_RAPIDS_VERSION=$(date +%Y-%m-%d -d "20${LATEST_RAPIDS_VERSION//./-}-01 + 2 month" | cut -c3-7 | tr - .)
+echo "DEV_RAPIDS_VERSION = $DEV_RAPIDS_VERSION"
+
+DIR_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+CONTAINER_YAML="$DIR_PATH/ci_container.yml"
+
+sed -i "s/\&rapids_version \"[[:digit:]]\+\.[[:digit:]]\+\"/\&rapids_version \"${LATEST_RAPIDS_VERSION}\"/" \
+  "$CONTAINER_YAML"
+sed -i "s/\&dev_rapids_version \"[[:digit:]]\+\.[[:digit:]]\+\"/\&dev_rapids_version \"${DEV_RAPIDS_VERSION}\"/" \
+  "$CONTAINER_YAML"


### PR DESCRIPTION
Containers are now built in xgboost-devops, so the logic for updating RAPIDS should also be moved there.