### PR TITLE
[CI] Temporarily pin pyspark<4.0; enforce libnccl version

### DIFF
--- a/containers/ci_container.yml
+++ b/containers/ci_container.yml
@@ -9,7 +9,7 @@ x-rapids_versions:
 
 x-cuda_versions:
   cuda: &cuda_version "12.8.0"
-  nccl: &nccl_version "2.25.1-1"
+  nccl: &nccl_version "2.26.2-1"
 
 xgb-ci.gpu_build_rockylinux8:
   container_def: gpu_build_rockylinux8

--- a/containers/conda_env/aarch64_test.yml
+++ b/containers/conda_env/aarch64_test.yml
@@ -28,7 +28,7 @@ dependencies:
 - llvmlite
 - loky>=3.5.1
 - pyarrow
-- pyspark>=3.4.0
+- pyspark>=3.4.0,<4.0
 - cloudpickle
 - pip:
   - awscli

--- a/containers/conda_env/linux_cpu_test.yml
+++ b/containers/conda_env/linux_cpu_test.yml
@@ -38,6 +38,6 @@ dependencies:
 - protobuf
 - cloudpickle
 - modin
-- pyspark>=3.4.0
+- pyspark>=3.4.0,<4.0
 - pip:
   - datatable

--- a/containers/dockerfile/Dockerfile.gpu
+++ b/containers/dockerfile/Dockerfile.gpu
@@ -17,9 +17,13 @@ ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 
 # Install all basic requirements
 RUN \
+    export CUDA_SHORT=`echo $CUDA_VERSION | grep -o -E '[0-9]+\.[0-9]'` && \
+    export NCCL_VERSION=$NCCL_VERSION && \
     apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub && \
     apt-get update && \
     apt-get install -y wget unzip bzip2 libgomp1 build-essential openjdk-8-jdk-headless && \
+    apt-get install "libnccl2=${NCCL_VERSION}+cuda${CUDA_SHORT}" \
+      "libnccl-dev=${NCCL_VERSION}+cuda${CUDA_SHORT}" -y --allow-change-held-packages && \
     # Miniforge
     wget -nv -O conda.sh https://github.com/conda-forge/miniforge/releases/download/$MINIFORGE_VERSION/Miniforge3-$MINIFORGE_VERSION-Linux-x86_64.sh && \
     bash conda.sh -b -p /opt/miniforge

--- a/containers/dockerfile/Dockerfile.gpu
+++ b/containers/dockerfile/Dockerfile.gpu
@@ -20,7 +20,6 @@ RUN \
     apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub && \
     apt-get update && \
     apt-get install -y wget unzip bzip2 libgomp1 build-essential openjdk-8-jdk-headless && \
-    apt-get install libnccl2 libnccl-dev -y --allow-change-held-packages && \
     # Miniforge
     wget -nv -O conda.sh https://github.com/conda-forge/miniforge/releases/download/$MINIFORGE_VERSION/Miniforge3-$MINIFORGE_VERSION-Linux-x86_64.sh && \
     bash conda.sh -b -p /opt/miniforge
@@ -31,7 +30,7 @@ RUN \
     export CUDA_SHORT_VER=$(echo "$CUDA_VERSION" | grep -o -E '[0-9]+\.[0-9]') && \
     mamba create -y -n gpu_test -c ${RAPIDSAI_CONDA_CHANNEL} -c conda-forge -c nvidia \
         python=$PYTHON_VERSION "cudf=$RAPIDS_VERSION.*" "rmm=$RAPIDS_VERSION.*" cuda-version=$CUDA_SHORT_VER \
-        "nccl>=${NCCL_SHORT_VER}" \
+        "nccl=${NCCL_SHORT_VER}" \
         dask \
         distributed \
         "dask-cuda=$RAPIDS_VERSION.*" "dask-cudf=$RAPIDS_VERSION.*" cupy \

--- a/containers/dockerfile/Dockerfile.gpu
+++ b/containers/dockerfile/Dockerfile.gpu
@@ -37,7 +37,7 @@ RUN \
         "dask-cuda=$RAPIDS_VERSION.*" "dask-cudf=$RAPIDS_VERSION.*" cupy \
         numpy pytest pytest-timeout scipy scikit-learn pandas matplotlib wheel \
         python-kubernetes urllib3 graphviz hypothesis "loky>=3.5.1" \
-        "pyspark>=3.4.0" cloudpickle cuda-python && \
+        "pyspark>=3.4.0,<4.0" cloudpickle cuda-python && \
     mamba clean --all --yes
 
 # Install lightweight sudo (not bound to TTY)


### PR DESCRIPTION
* Work around https://github.com/dmlc/xgboost/issues/11498 by temporarily adding pin `pyspark<4`
* Install specific version of libnccl in `xgb-ci.gpu` container. This is important because the base CUDA container already contains a different version of libnccl, and an incompatible version of NCCL may lead to crashes, e.g. [here](https://github.com/dmlc/xgboost/actions/runs/15480321046/job/43585317798?pr=11501) and [here](https://github.com/dmlc/xgboost/actions/runs/15480321046/job/43585317793)

cc @trivialfis 