### PR TITLE
Downgrade rapids to 2602 for now.

### DIFF
--- a/containers/ci_container.yml
+++ b/containers/ci_container.yml
@@ -4,7 +4,7 @@
 # containers/dockerfile/Dockerfile.CONTAINER_DEF
 
 x-rapids_versions:
-  stable: &rapids_version "26.04"
+  stable: &rapids_version "26.02"
 
 x-cuda_versions:
   cuda: &cuda_version "12.9.0"


### PR DESCRIPTION
Handle Python version conflict in followup PRs. I need to unblock the CI.